### PR TITLE
Add support to positional commands, some with aliases. Import the re.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Build
 Status](https://travis-ci.org/lsrdg/tatoeba-karini.svg?branch=master)](https://travis-ci.org/lsrdg/tatoeba-karini)
 
----
-
 tatoeba.org from the command line.
 
 Tatoeba-karini can assist you on opening and scrapping tatoeba.org from the
@@ -50,13 +48,13 @@ exists, both terms of code and user experience.
 **Long term**: improve what already exists and add more functionality 
 
 - to be an alternative to offline use of Tatoeba
-- export data (`.csv` files, e.g. to be used on [Anki](https://apps.ankiweb.net/)
+- export data (`.csv` files, e.g. to be used on [Anki](https://apps.ankiweb.net/))
 - strong REGEX parser
 - more ways to interact with Tatoeba and all the material provided by it
 
 ## Requirements 
 
-Python 3.\*. It was written on Archlinux with Python 3.6.
+Python 3.\*. It was written on Arch Linux with Python 3.6.
 Theoretically, it should work on any system with support to Python 3.
 
 For a complete list, please take a look at
@@ -67,24 +65,23 @@ environment.
 
 ### Requirements for offline searches
 
-If you want to make use of the `-f` command (to perform offline searches), make
+If you want to make use of the `find` command (to perform offline searches), make
 sure have the file containing the sentences:
 [sentences.csv](http://downloads.tatoeba.org/exports/sentences.tar.bz2).
 
-The command `-s` makes use of the `sentences.csv` *and*:
-[links.csv](http://downloads.tatoeba.org/exports/links.tar.bz2).
+The `translate` command makes use of the `sentences.csv` mentioned above *and* [links.csv](http://downloads.tatoeba.org/exports/links.tar.bz2).
 
 The files should be: 
 - downloaded (yes, that's right, more than 80MB, about 5511497 lines of pure joy)
 - decompressed (`$ tar -xvfj sentences.csv`)
 - be sure it is placed on the root of the Tatoeba-karini directory
 
-**Heads up!** The `-d` command can download and prepare the file for you.
+**Heads up!** The `download` command can... erh, download and prepare the file for you.
 
 ## Usage 
 
 ```
-python tatoeba-karini [OPTION] [OPTION'S ARGUMENTS]
+python tatoeba-karini [COMMAND] [ARGUMENT(S)]
 ```
 
 The script can perform different actions, such as:
@@ -94,33 +91,33 @@ The script can perform different actions, such as:
 - Search off line making use of the [sentences' file](https://tatoeba.org/eng/downloads)
 
 
-| Optional command | Description                                                                                                             | Required arguments | Syntax                                  | Example                                  |
-|------------------|-------------------------------------------------------------------------------------------------------------------------|--------------------|-----------------------------------------|------------------------------------------|
-| -b               | Open the browser in a new tab performing a search on tatoeba.org                                                        | 3                  | -b [FROM-LANGUAGE] [TO-LANGUAGE]        | `$ tatoeba-karini -b eng jpn breath`     |
-| -f               | Find sentences in X language containing the Y-term                                                                      | 2                  | -f [IN-LANGUAGE] [TERM]                 | `$ tatoeba-karini -f yor water`          |
-| -l               | List languages and their abbreviation used by Tatoeba                                                                   | 1                  | -l [LANGUAGE-NAME]                      | `$ tatoeba-karini -l Japanese`           |
-| -r               | Request from Tatoeba.org. Works in the same way as the main search on the website                                       | 3                  | -r [FROM-LANGUAGE] [TO-LANGUAGE] [TERM] | `$ tatoeba-karini -r eng ara watermelon` |
-| -s               | Search for sentences containing term in a specific language and it the counterparts of the sentence in another language | 3                  | -s [IN-LANGUAGE] [TO-LANGUAGE] [TERM]   | `$ tatoeba-karini -s eng jpn air`        |
-| -i               | Open Tatoeba on the browser searching by sentence's ID                                                                  | 1                  | -i [SENTENCE'S-ID]                      | `$ tatoeba-karini -i 825762`             |
-| -d               | Download files (`links` or `sentences`) from Tatoeba.org in order to perform offline searchs                            | 1                  | -d [FILE]                               | `$ tatoeba-karini -d links`              |
+| Positional command | Description                                                                                                             | Required arguments | Example                                  |
+|------------------|-------------------------------------------------------------------------------------------------------------------------|--------------------|------------------------------------------|
+| `browser` (or `b`)               | Open the browser in a new tab performing a search on tatoeba.org                                                        | 3 | `$ tatoeba-karini -b eng jpn breath`     | 
+| `find` (or `f`)               | Find sentences in X language containing the Y-term                                                                      | 2 |  `$ tatoeba-karini find yor water`          |
+| `list-languages`               | List languages and their abbreviation used by Tatoeba                                                                   | 1 |  `$ tatoeba-karini list-languages Japanese`           |
+| `scrap` (or `s`               | Scrap Tatoeba.org. Works in the same way as the main search on the website                                       | 3 |  `$ tatoeba-karini scrap eng ara watermelon` |
+| `translate` (or `t`)               | Search for sentences containing term in a specific language and the translation of the sentences in another language | 3 | `$ tatoeba-karini translate eng jpn air`        |
+| `id`               | Open Tatoeba on the browser searching by sentence's ID | 1                  | `$ tatoeba-karini id 825762`             |
+| `download`               | Download files (`links` or `sentences`) from Tatoeba.org in order to perform offline searches                            | 1 | `$ tatoeba-karini download links`              |
 
 
 ### Notes
 
 About the commands and their current state:
 
-- There are two commands for **opening** Tatoeba.org from the command line (`-b`,
-  `-i`), and they _should_ just work. There are also other commands that should
-  get their own 'open in the browser' version on the future.
+- There are two commands for **opening** Tatoeba.org from the command line
+  (`browser`, `id`), and they _should_ just work. There are also other commands
+  that might get their own 'open in the browser' version on the future.
 
-- All the offline commands need improvement. `-f` is working pretty well for my
-  personal use, but still need some REGEX to work as it should. `-s` is the worst 
+- All the offline commands need improvement. `find` is working pretty well for my
+  personal use, but still need some REGEX to work as it should. `translate` is the worst 
   of all of them, taking several minutes to perform even the most basic search.
   The inefficiency of these commands reflect how much I need to learn, any help
   welcome. (:
 
-- The fetching/scrapping command `-r` is not perfect, but it is what I had in
-  mind before this project got started. A better support for multiple pages planned.
+- The fetching/scrapping command `scrap` is not perfect, but it is what I had in
+  mind before this project got started. A better support for multiple pages is planned.
   
 ## License
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The script can perform different actions, such as:
 | `id`               | Open Tatoeba on the browser searching by sentence's ID | 1                  | `$ tatoeba-karini id 825762`             |
 | `download`               | Download files (`links` or `sentences`) from Tatoeba.org in order to perform offline searches                            | 1 | `$ tatoeba-karini download links`              |
 
+> Need help? `$ tatoeba-karini --help` will show a list of the commands, what
+> they do and tell you what you need to make them work.
 
 ### Notes
 


### PR DESCRIPTION
This PR changes from optional (`-b`) to positional commands (`browser`). The most used commands have also a short form: `browser` can be shortened to `b`.

It also imports and makes use of the re module.

Most of the commands, just got a "longer" name. However, some were chaged:

* `-l` is now `list-languages`
* `-r` is now `scrap` (or `s`)
* `-s` is now `translate` (or `t`)

README needs to be updated.