### PR TITLE
Issue 61 rename list languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The script can perform different actions, such as:
 |------------------|-------------------------------------------------------------------------------------------------------------------------|--------------------|------------------------------------------|
 | `browser` (or `b`)               | Open the browser in a new tab performing a search on tatoeba.org                                                        | 3 | `$ tatoeba-karini -b eng jpn breath`     | 
 | `find` (or `f`)               | Find sentences in X language containing the Y-term                                                                      | 2 |  `$ tatoeba-karini find yor water`          |
-| `list-languages`               | List languages and their abbreviation used by Tatoeba                                                                   | 1 |  `$ tatoeba-karini list-languages Japanese`           |
+| `abbreviate`               | List languages and their abbreviation used by Tatoeba                                                                   | 1 |  `$ tatoeba-karini abbreviate Japanese`           |
 | `scrap` (or `s`               | Scrap Tatoeba.org. Works in the same way as the main search on the website                                       | 3 |  `$ tatoeba-karini scrap eng ara watermelon` |
 | `translate` (or `t`)               | Search for sentences containing term in a specific language and the translation of the sentences in another language | 3 | `$ tatoeba-karini translate eng jpn air`        |
 | `id`               | Open Tatoeba on the browser searching by sentence's ID | 1                  | `$ tatoeba-karini id 825762`             |

--- a/tatoeba-karini-manpage.1
+++ b/tatoeba-karini-manpage.1
@@ -21,7 +21,7 @@ Locally, find all sentences in the given [TARGET-LANGUAGE] containing [PATTERN]
 .RE
 .LP
 .BR tatoeba-karini
-.R list-languages
+.R abbreviate
 .I [LANGUAGE]
 .RS
 Returns a list containing the abbreviation of the given [LANGUAGE]

--- a/tatoeba_karini.py
+++ b/tatoeba_karini.py
@@ -344,7 +344,7 @@ def parse_arguments():
 
     parser = argparse.ArgumentParser("tatoeba-karini [COMMAND] [ARGUMENT(S)]")
 
-    parser.add_argument("--version", "-v", action="version", version="v0.0.6")
+    parser.add_argument("--version", "-v", action="version", version="v0.0.6+")
 
     subparsers = parser.add_subparsers(help="Types of commands")
 

--- a/tatoeba_karini.py
+++ b/tatoeba_karini.py
@@ -383,12 +383,12 @@ def parse_arguments():
     id_parser.add_argument("target_id", type=int, help="The target ID")
     id_parser.set_defaults(func=id_wrapper)
 
-    list_languages_parser = subparsers.add_parser("list-languages", help="List \
-            languages and their abbreviation used by Tatoeba. Usage: \
-            tatoeba-karini list-languages [target_language]")
-    list_languages_parser.add_argument("target_language", type=str, help="The \
+    abbreviate_parser = subparsers.add_parser("abbreviate", aliases=["ab"], \
+            help="List languages and their abbreviation used by Tatoeba. \
+            Usage: tatoeba-karini abbreviate [target_language]")
+    abbreviate_parser.add_argument("target_language", type=str, help="The \
             abbreviation of the target language name")
-    list_languages_parser.set_defaults(func=list_abbreviation_wrapper)
+    abbreviate_parser.set_defaults(func=list_abbreviation_wrapper)
 
     scrap_parser = subparsers.add_parser("scrap", aliases=["s"], help="Scrap \
             data from Tatoeba.org performing a search. \


### PR DESCRIPTION
Renaming `list-languages` to `abbreviate` (or `ab`) since it is not a list of languages but a list of abbreviations. If that makes any sense at all.