### PR TITLE
'Pattern not found' if empty list returned by the 'abbreviate' command.

### DIFF
--- a/tatoeba_karini.py
+++ b/tatoeba_karini.py
@@ -231,7 +231,11 @@ def list_abbreviation_wrapper(search_pattern):
             row for row in abbrev_list if search_pattern in map(
                 str.lower, row)
             ]
-        print(abbreviation)
+
+        if not abbreviation:
+            print("Pattern not found. Please, check your spelling.")
+        else:
+            print(abbreviation)
 
 
 # Fetching

--- a/tatoeba_karini.py
+++ b/tatoeba_karini.py
@@ -232,10 +232,21 @@ def list_abbreviation_wrapper(search_pattern):
                 str.lower, row)
             ]
 
-        if not abbreviation:
-            print("Pattern not found. Please, check your spelling.")
-        else:
-            print(abbreviation)
+        try:
+            print(abbreviation[0])
+
+        except IndexError:
+            print("""
+            Pattern not found! Possible solutions:
+
+            1 - Please, check your spelling and try again
+            2 - Go to tatoeba.org and check if the language is supported
+                  If the language is supported by tatoeba.org but not here, please
+                  open an issue at https://github.com/lsrdg/tatoeba-karini/wiki
+            3 - Tatoeba-karini is shipped with the file abbreviation_list.csv which
+                can be checked manually
+    
+            """)
 
 
 # Fetching


### PR DESCRIPTION
If `abbreviate` returns an empty list, an error won't be raised, but the user will receive a "_pattern not found_" message. Closes #64 .